### PR TITLE
update pytorch version for bicubic interp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy==1.16.2
 setuptools==40.8.0
 matplotlib==3.0.3
 scipy==1.2.1
-torch==1.0.0
+torch==1.1.0
 yacs==0.1.6
 graphviz==0.11.1
 Pillow==6.1.0


### PR DESCRIPTION
Update pytorch version to solve issue https://github.com/hkzhang91/HiNAS/issues/2#issue-1071151937

`one_stage_nas/modeling/sr_compnet.py`, line 214 uses `torch.nn.functional.interpolate` is called with the `bicubic` argument, which is only introduced in pytorch 1.1.0 (see: https://pytorch.org/docs/1.1.0/nn.html?highlight=interpolate#torch.nn.functional.interpolate), and does not yet exist in pytorch 1.0.0 (see: https://pytorch.org/docs/1.0.0/nn.html?highlight=interpolate#torch.nn.functional.interpolate). Bug is solved by upgrading to pytorch 1.1.0, using instructions [here](https://pytorch.org/get-started/previous-versions/#v110).