### PR TITLE
remove cuda=false in ssim loss

### DIFF
--- a/one_stage_nas/modeling/sr_compnet.py
+++ b/one_stage_nas/modeling/sr_compnet.py
@@ -168,7 +168,7 @@ class Sr_compnet(nn.Module):
             self.loss_weight = []
             for loss_item, loss_weight in zip(cfg.SOLVER.LOSS, cfg.SOLVER.LOSS_WEIGHT):
                 if 'ssim' in loss_item or 'grad' in loss_item:
-                    self.loss_dict.append(loss_dict[loss_item](channel=3, is_cuda=False))
+                    self.loss_dict.append(loss_dict[loss_item](channel=3))
                 else:
                     self.loss_dict.append(loss_dict[loss_item]())
                 self.loss_weight.append(loss_weight)


### PR DESCRIPTION
pull request to fix issue https://github.com/hkzhang91/HiNAS/issues/3#issue-1079521715

removing the `cuda =False` argument in line 121 of one_stage_nas/modeling/sr_compnet.py removes the issue. The problem occurred because the loss was on CPU, but training data + model on GPU.